### PR TITLE
Added ability to manage blocking right calendar by start date - again

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -252,6 +252,9 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
   @Input()
   customTimezone: string = null;
 
+  @Input()
+  blockRightCalendarByStartDate: boolean = true;
+
   @Input() drops: string;
   @Input() opens: string;
   @Input() closeOnAutoApply = true;
@@ -675,7 +678,7 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
     //
     // Display the calendar
     //
-    let minDate = side === 'left' ? this.minDate : this.startDate;
+    let minDate = side === 'left' || !this.blockRightCalendarByStartDate ? this.minDate : this.startDate;
     let maxDate = this.maxDate;
     // adjust maxDate to reflect the dateLimit setting in order to
     // grey out end dates beyond the dateLimit

--- a/src/daterangepicker/daterangepicker.directive.ts
+++ b/src/daterangepicker/daterangepicker.directive.ts
@@ -93,6 +93,9 @@ export class DaterangepickerDirective implements OnInit, OnChanges, DoCheck {
 
   @Input()
   customRangeDirection: boolean;
+  
+  @Input()
+  blockRightCalendarByStartDate: boolean;
 
   @Input()
   ranges: DateRanges;


### PR DESCRIPTION
Restore feature added in https://github.com/IterativeEngineering/ngx-daterangepicker-material/commit/bb29c72975e80802e00d29bae12f243a3b8f53e1 after I synced this fork repo with original library repo.