### PR TITLE
Fix handling time ranges

### DIFF
--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -1285,11 +1285,6 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
       }
       this.showCalInRanges = !this.rangesArray.length || this.alwaysShowCalendars;
 
-      if (!this.timePicker) {
-        this.startDate = this.startDate.startOf('day');
-        this.endDate = this.endDate.endOf('day');
-      }
-
       if (!this.alwaysShowCalendars) {
         this.isShown = false; // hide calendars
       }


### PR DESCRIPTION
DaterangepickerComponent contained a seemingly unneeded piece of code, which manipulated dates in ranges to set start to the start of day and end date to the end of date. This code broke our flow and the dates were off by one hour, which seems to be caused by DST.