### PR TITLE
remove date range picker hover shadow after selection

### DIFF
--- a/demo/src/app/simple/simple.component.html
+++ b/demo/src/app/simple/simple.component.html
@@ -68,6 +68,7 @@
             [startDate]="selected?.startDate"
             [endDate]="selected?.endDate"
             [timePicker]="true"
+            [customRangeDirection]="true"
             [locale]="{ applyLabel: 'Done', firstDay: 1 }"></ngx-daterangepicker-material>
         <br />
         <p>Chosen date (after changes): {{ selected | json }}</p>

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -781,6 +781,10 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
       }
     }
 
+    if (this.endDate) {
+      this.pickingDate = false;
+    }
+
     if (!this.isShown) {
       this.updateElement();
     }
@@ -821,6 +825,10 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
 
     if (this.dateLimit && this.startDate.clone().add(this.dateLimit, 'day').isBefore(this.endDate)) {
       this.endDate = this.startDate.clone().add(this.dateLimit, 'day');
+    }
+
+    if (this.startDate) {
+      this.pickingDate = false;
     }
 
     if (!this.isShown) {


### PR DESCRIPTION
Remove the shadow that follows mouse pointer when selecting date range. It was an issue on backward selection (end date first) and forward selection (start date first) when time picker was enabled.