### PR TITLE
added corrected tz and utc plugins for dayjs

### DIFF
--- a/demo/src/app/full/full.component.ts
+++ b/demo/src/app/full/full.component.ts
@@ -3,6 +3,8 @@ import dayjs from 'dayjs/esm';
 import { DaterangepickerDirective } from '../../../../src/daterangepicker/daterangepicker.directive';
 import { EndDate, StartDate } from '../../../../src/daterangepicker/daterangepicker.component';
 import { LocaleConfig } from '../../../../src/daterangepicker';
+import timezone from '../../../../plugin-overrides/timezone';
+dayjs.extend(timezone)
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector

--- a/demo/src/app/locale/locale.component.ts
+++ b/demo/src/app/locale/locale.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import dayjs from 'dayjs/esm';
-import utc from 'dayjs/esm/plugin/utc';
+import utc from '../../../../plugin-overrides/utc'
 import * as fr from 'dayjs/locale/fr';
 import { DaterangepickerDirective } from '../../../../src/daterangepicker';
 dayjs.extend(utc);

--- a/demo/src/app/simple/simple.component.ts
+++ b/demo/src/app/simple/simple.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import dayjs from 'dayjs/esm';
-import utc from 'dayjs/esm/plugin/utc';
-dayjs.extend(utc);
+import utc from '../../../../plugin-overrides/utc'
 import { DaterangepickerComponent, DaterangepickerDirective } from '../../../../src/daterangepicker';
 import { ChosenDate, TimePeriod } from '../../../../src/daterangepicker/daterangepicker.component';
+dayjs.extend(utc )
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector

--- a/plugin-overrides/timezone/index.d.ts
+++ b/plugin-overrides/timezone/index.d.ts
@@ -1,0 +1,20 @@
+import { PluginFunc, ConfigType } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs/esm' {
+  interface Dayjs {
+    tz(timezone?: string, keepLocalTime?: boolean): Dayjs
+    offsetName(type?: 'short' | 'long'): string | undefined
+  }
+
+  interface DayjsTimezone {
+    (date?: ConfigType, timezone?: string): Dayjs
+    (date: ConfigType, format: string, timezone?: string): Dayjs
+    guess(): string
+    setDefault(timezone?: string): void
+  }
+
+  const tz: DayjsTimezone
+}

--- a/plugin-overrides/timezone/index.js
+++ b/plugin-overrides/timezone/index.js
@@ -1,0 +1,184 @@
+/*
+  This is a copy of timezone plugin from dayjs v.1.11.10 with a bug fix merged: https://github.com/iamkun/dayjs/pull/2264
+  Any updates to the plugin must be done manually, unless the underlying issue has been finally fixed.
+*/
+
+export const SECONDS_A_MINUTE = 60
+export const SECONDS_A_HOUR = SECONDS_A_MINUTE * 60
+export const SECONDS_A_DAY = SECONDS_A_HOUR * 24
+export const SECONDS_A_WEEK = SECONDS_A_DAY * 7
+
+export const MILLISECONDS_A_SECOND = 1e3
+export const MILLISECONDS_A_MINUTE = SECONDS_A_MINUTE * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_HOUR = SECONDS_A_HOUR * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_DAY = SECONDS_A_DAY * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_WEEK = SECONDS_A_WEEK * MILLISECONDS_A_SECOND
+
+// English locales
+export const MS = 'millisecond'
+export const S = 'second'
+export const MIN = 'minute'
+export const H = 'hour'
+export const D = 'day'
+export const W = 'week'
+export const M = 'month'
+export const Q = 'quarter'
+export const Y = 'year'
+export const DATE = 'date'
+
+export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
+
+export const INVALID_DATE_STRING = 'Invalid Date'
+
+// regex
+export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
+export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+
+const typeToPos = {
+  year: 0,
+  month: 1,
+  day: 2,
+  hour: 3,
+  minute: 4,
+  second: 5
+}
+
+// Cache time-zone lookups from Intl.DateTimeFormat,
+// as it is a *very* slow method.
+const dtfCache = {}
+const getDateTimeFormat = (timezone, options = {}) => {
+  const timeZoneName = options.timeZoneName || 'short'
+  const key = `${timezone}|${timeZoneName}`
+  let dtf = dtfCache[key]
+  if (!dtf) {
+    dtf = new Intl.DateTimeFormat('en-US', {
+      hour12: false,
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName
+    })
+    dtfCache[key] = dtf
+  }
+  return dtf
+}
+
+export default (o, c, d) => {
+  let defaultTimezone
+
+  const makeFormatParts = (timestamp, timezone, options = {}) => {
+    const date = new Date(timestamp)
+    const dtf = getDateTimeFormat(timezone, options)
+    return dtf.formatToParts(date)
+  }
+
+  const tzOffset = (timestamp, timezone) => {
+    const formatResult = makeFormatParts(timestamp, timezone)
+    const filled = []
+    for (let i = 0; i < formatResult.length; i += 1) {
+      const { type, value } = formatResult[i]
+      const pos = typeToPos[type]
+
+      if (pos >= 0) {
+        filled[pos] = parseInt(value, 10)
+      }
+    }
+    const hour = filled[3]
+    // Workaround for the same behavior in different node version
+    // https://github.com/nodejs/node/issues/33027
+    /* istanbul ignore next */
+    const fixedHour = hour === 24 ? 0 : hour
+    const utcString = `${filled[0]}-${filled[1]}-${filled[2]} ${fixedHour}:${filled[4]}:${filled[5]}:000`
+    const utcTs = d.utc(utcString).valueOf()
+    let asTS = +timestamp
+    const over = asTS % 1000
+    asTS -= over
+    return (utcTs - asTS) / (60 * 1000)
+  }
+
+  // find the right offset a given local time. The o input is our guess, which determines which
+  // offset we'll pick in ambiguous cases (e.g. there are two 3 AMs b/c Fallback DST)
+  // https://github.com/moment/luxon/blob/master/src/datetime.js#L76
+  const fixOffset = (localTS, o0, tz) => {
+    // Our UTC time is just a guess because our offset is just a guess
+    let utcGuess = localTS - (o0 * 60 * 1000)
+    // Test whether the zone matches the offset for this ts
+    const o2 = tzOffset(utcGuess, tz)
+    // If so, offset didn't change and we're done
+    if (o0 === o2) {
+      return [utcGuess, o0]
+    }
+    // If not, change the ts by the difference in the offset
+    utcGuess -= (o2 - o0) * 60 * 1000
+    // If that gives us the local time we want, we're done
+    const o3 = tzOffset(utcGuess, tz)
+    if (o2 === o3) {
+      return [utcGuess, o2]
+    }
+    // If it's different, we're in a hole time.
+    // The offset has changed, but the we don't adjust the time
+    return [localTS - (Math.min(o2, o3) * 60 * 1000), Math.max(o2, o3)]
+  }
+
+  const proto = c.prototype
+
+  proto.tz = function (timezone = defaultTimezone, keepLocalTime) {
+    const oldOffset = this.utcOffset()
+    const date = this.toDate()
+    const target = date.toLocaleString('en-US', { timeZone: timezone })
+    const diff = Math.round((date - new Date(target)) / 1000 / 60)
+    let ins = d(target, { locale: this.$L }).$set(MS, this.$ms)
+      .utcOffset((-Math.round(date.getTimezoneOffset() / 15) * 15) - diff, true, timezone !== 'UTC')
+    if (keepLocalTime) {
+      const newOffset = ins.utcOffset()
+      ins = ins.add(oldOffset - newOffset, MIN)
+    }
+    ins.$x.$timezone = timezone
+    return ins
+  }
+
+  proto.offsetName = function (type) {
+    // type: short(default) / long
+    const zone = this.$x.$timezone || d.tz.guess()
+    const result = makeFormatParts(this.valueOf(), zone, { timeZoneName: type }).find(m => m.type.toLowerCase() === 'timezonename')
+    return result && result.value
+  }
+
+  const oldStartOf = proto.startOf
+  proto.startOf = function (units, startOf) {
+    if (!this.$x || !this.$x.$timezone) {
+      return oldStartOf.call(this, units, startOf)
+    }
+
+    const withoutTz = d(this.format('YYYY-MM-DD HH:mm:ss:SSS'), { locale: this.$L })
+    const startOfWithoutTz = oldStartOf.call(withoutTz, units, startOf)
+    return startOfWithoutTz.tz(this.$x.$timezone, true)
+  }
+
+  d.tz = function (input, arg1, arg2) {
+    const parseFormat = arg2 && arg1
+    const timezone = arg2 || arg1 || defaultTimezone
+    const previousOffset = tzOffset(+d(), timezone)
+    if (typeof input !== 'string') {
+      // timestamp number || js Date || Day.js
+      return d(input).tz(timezone)
+    }
+    const localTs = d.utc(input, parseFormat).valueOf()
+    const [targetTs, targetOffset] = fixOffset(localTs, previousOffset, timezone)
+    const ins = d(targetTs).utcOffset(targetOffset, false, timezone !== 'UTC')
+    ins.$x.$timezone = timezone
+    return ins
+  }
+
+  d.tz.guess = function () {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  }
+
+  d.tz.setDefault = function (timezone) {
+    defaultTimezone = timezone
+  }
+}

--- a/plugin-overrides/utc/index.d.ts
+++ b/plugin-overrides/utc/index.d.ts
@@ -1,0 +1,19 @@
+import { PluginFunc, ConfigType } from 'dayjs/esm'
+
+declare const plugin: PluginFunc
+export = plugin
+
+declare module 'dayjs/esm' {
+  interface Dayjs {
+    
+    utc(keepLocalTime?: boolean): Dayjs
+    
+    local(): Dayjs
+
+    isUTC(): boolean
+
+    utcOffset(offset: number | string, keepLocalTime?: boolean): Dayjs
+  }
+
+  export function utc(config?: ConfigType, format?: string, strict?: boolean): Dayjs
+}

--- a/plugin-overrides/utc/index.js
+++ b/plugin-overrides/utc/index.js
@@ -1,0 +1,185 @@
+/*
+  This is a copy of UTC plugin from dayjs v.1.11.10 with a bug fix merged: https://github.com/iamkun/dayjs/pull/2264
+  Any updates to the plugin must be done manually, unless the underlying issue has been finally fixed.
+*/
+
+export const SECONDS_A_MINUTE = 60
+export const SECONDS_A_HOUR = SECONDS_A_MINUTE * 60
+export const SECONDS_A_DAY = SECONDS_A_HOUR * 24
+export const SECONDS_A_WEEK = SECONDS_A_DAY * 7
+
+export const MILLISECONDS_A_SECOND = 1e3
+export const MILLISECONDS_A_MINUTE = SECONDS_A_MINUTE * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_HOUR = SECONDS_A_HOUR * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_DAY = SECONDS_A_DAY * MILLISECONDS_A_SECOND
+export const MILLISECONDS_A_WEEK = SECONDS_A_WEEK * MILLISECONDS_A_SECOND
+
+// English locales
+export const MS = 'millisecond'
+export const S = 'second'
+export const MIN = 'minute'
+export const H = 'hour'
+export const D = 'day'
+export const W = 'week'
+export const M = 'month'
+export const Q = 'quarter'
+export const Y = 'year'
+export const DATE = 'date'
+
+export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
+
+export const INVALID_DATE_STRING = 'Invalid Date'
+
+// regex
+export const REGEX_PARSE = /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
+export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g
+
+const REGEX_VALID_OFFSET_FORMAT = /[+-]\d\d(?::?\d\d)?/g
+const REGEX_OFFSET_HOURS_MINUTES_FORMAT = /([+-]|\d\d)/g
+
+function offsetFromString(value = '') {
+  const offset = value.match(REGEX_VALID_OFFSET_FORMAT)
+
+  if (!offset) {
+    return null
+  }
+
+  const [indicator, hoursOffset, minutesOffset] = `${offset[0]}`.match(REGEX_OFFSET_HOURS_MINUTES_FORMAT) || ['-', 0, 0]
+  const totalOffsetInMinutes = (+hoursOffset * 60) + (+minutesOffset)
+
+  if (totalOffsetInMinutes === 0) {
+    return 0
+  }
+
+  return indicator === '+' ? totalOffsetInMinutes : -totalOffsetInMinutes
+}
+
+
+
+export default (option, Dayjs, dayjs) => {
+  const proto = Dayjs.prototype 
+  dayjs.utc = function (date) {
+    const cfg = { date, utc: true, args: arguments } // eslint-disable-line prefer-rest-params
+    return new Dayjs(cfg ) // eslint-disable-line no-use-before-define
+  }
+
+  proto.utc = function (keepLocalTime) {
+    const ins = dayjs(this.toDate(), { locale: this.$L, utc: true })
+    if (keepLocalTime) {
+      return ins.add(this.utcOffset(), MIN)
+    }
+    return ins
+  }
+
+  proto.local = function () {
+    return dayjs(this.toDate(), { locale: this.$L, utc: false })
+  }
+
+  const oldParse = proto.parse
+  proto.parse = function (cfg) {
+    if (cfg.utc) {
+      this.$u = true
+    }
+    if (!this.$utils().u(cfg.$offset)) {
+      this.$offset = cfg.$offset
+    }
+    oldParse.call(this, cfg)
+  }
+
+  const oldInit = proto.init
+  proto.init = function () {
+    if (this.$u) {
+      const { $d } = this
+      this.$y = $d.getUTCFullYear()
+      this.$M = $d.getUTCMonth()
+      this.$D = $d.getUTCDate()
+      this.$W = $d.getUTCDay()
+      this.$H = $d.getUTCHours()
+      this.$m = $d.getUTCMinutes()
+      this.$s = $d.getUTCSeconds()
+      this.$ms = $d.getUTCMilliseconds()
+    } else {
+      oldInit.call(this)
+    }
+  }
+
+  const oldUtcOffset = proto.utcOffset
+  proto.utcOffset = function (input, keepLocalTime, keepTimezone) {
+    const { u } = this.$utils()
+    if (u(input)) {
+      if (this.$u) {
+        return 0
+      }
+      if (!u(this.$offset)) {
+        return this.$offset
+      }
+      return oldUtcOffset.call(this)
+    }
+    if (typeof input === 'string') {
+      input = offsetFromString(input)
+      if (input === null) {
+        return this
+      }
+    }
+    const offset = Math.abs(input) <= 16 ? input * 60 : input
+    let ins = this
+    if (keepLocalTime) {
+      ins.$offset = offset
+      ins.$u = input === 0 && !keepTimezone
+      return ins
+    }
+    if (input !== 0 || keepTimezone) {
+      const localTimezoneOffset = this.$u
+        ? this.toDate().getTimezoneOffset() : -1 * this.utcOffset()
+      ins = this.local().add(offset + localTimezoneOffset, MIN)
+      ins.$offset = offset
+      ins.$x.$localOffset = localTimezoneOffset
+      ins.$u = input === 0 && !keepTimezone
+    } else {
+      ins = this.utc()
+    }
+    return ins
+  }
+
+  const oldFormat = proto.format
+  const UTC_FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ss[Z]'
+  proto.format = function (formatStr) {
+    const str = formatStr || (this.$u ? UTC_FORMAT_DEFAULT : '')
+    return oldFormat.call(this, str)
+  }
+
+  proto.valueOf = function () {
+    const addedOffset = !this.$utils().u(this.$offset)
+      ? this.$offset + (this.$x.$localOffset || this.$d.getTimezoneOffset()) : 0
+    return this.$d.valueOf() - (addedOffset * MILLISECONDS_A_MINUTE)
+  }
+
+  proto.isUTC = function () {
+    return !!this.$u
+  }
+
+  proto.toISOString = function () {
+    return this.toDate().toISOString()
+  }
+
+  proto.toString = function () {
+    return this.toDate().toUTCString()
+  }
+
+  const oldToDate = proto.toDate
+  proto.toDate = function (type) {
+    if (type === 's' && this.$offset) {
+      return dayjs(this.format('YYYY-MM-DD HH:mm:ss:SSS')).toDate()
+    }
+    return oldToDate.call(this)
+  }
+  const oldDiff = proto.diff
+  proto.diff = function (input, units, float) {
+    if (input && this.$u === input.$u) {
+      return oldDiff.call(this, input, units, float)
+    }
+    const localThis = this.local()
+    const localInput = dayjs(input).local()
+    return oldDiff.call(localThis, localInput, units, float)
+  }
+} 

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -23,8 +23,8 @@ import LocalizedFormat from 'dayjs/esm/plugin/localizedFormat';
 import isoWeek from 'dayjs/esm/plugin/isoWeek';
 import week from 'dayjs/esm/plugin/weekOfYear';
 import customParseFormat from 'dayjs/esm/plugin/customParseFormat';
-import utc from 'dayjs/esm/plugin/utc';
-import timezone from 'dayjs/esm/plugin/timezone';
+import utc from '../../plugin-overrides/utc';
+import timezone from '../../plugin-overrides/timezone';
 
 dayjs.extend(localeData);
 dayjs.extend(LocalizedFormat);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
         "strictTemplates": true,
         "compilationMode": "partial"
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "plugin-overrides"],
     "exclude": ["node_modules", "**/*.spec.ts", "schematics"]
 }


### PR DESCRIPTION
Several issues are fixed by this, all are related to UTC dates.

- calendar initial view not showing the correct start month
- single selection sets a different day
- multiselection selects different dates than clicked