### PR TITLE
Remove gray bg when calendar range is hovered

### DIFF
--- a/src/daterangepicker/daterangepicker.component.scss
+++ b/src/daterangepicker/daterangepicker.component.scss
@@ -638,9 +638,6 @@ $input-height: 3rem !default;
           }
         }
       }
-      li:hover {
-        background-color: #eee;
-      }
     }
   }
 


### PR DESCRIPTION
Remove gray bg when hovering over CUSTOM range
![image](https://github.com/IterativeEngineering/ngx-daterangepicker-material/assets/56605753/1a99033a-0aae-4335-bb76-898b0c4dab67)
