### PR TITLE
Date picker improvements

### DIFF
--- a/src/daterangepicker/daterangepicker.component.html
+++ b/src/daterangepicker/daterangepicker.component.html
@@ -135,20 +135,8 @@
                 </table>
             </div>
         </div>
-        <div class="timepicker" *ngIf="timePicker">
-            <div class="select-header">START: </div>
-            <div class="select-content">
-                <div class="input-field">
-                    <label for="dateStart">Date</label>
-                    <input type="text" 
-                    disabled="true"
-                    class="disabled"
-                    [value]="dateStart | date:'yyyy-MM-dd'" />
-                </div>
-                <div class="input-field">
-                    <ng-content select="[slot=start]"></ng-content>
-                </div>
-            </div>
+        <div class="timepicker d-none d-md-flex" *ngIf="timePicker">
+            <ng-container [ngTemplateOutlet]="startTimePickerTpl"></ng-container>
         </div>
     </div>
 
@@ -263,19 +251,24 @@
                 </table>
             </div>
         </div>
-        <div class="timepicker" *ngIf="timePicker">
-            <div class="select-header">END: </div>
-            <div class="select-content">
-                <div class="input-field">
-                    <label for="dateStart">Date</label>
-                    <input type="text"
-                        name="dateStart" 
-                        disabled="true"
-                        class="disabled"
-                        [value]="dateEnd | date:'yyyy-MM-dd'" />    
-                </div>
-                <div class="input-field">
-                    <ng-content select="[slot=end]"></ng-content>
+        <div class="d-flex justify-content-between">
+            <div class="timepicker d-md-none" *ngIf="timePicker">
+                <ng-container [ngTemplateOutlet]="startTimePickerTpl"></ng-container>
+            </div>
+            <div class="timepicker" *ngIf="timePicker">
+                <div class="select-header">END: </div>
+                <div class="select-content">
+                    <div class="input-field">
+                        <label for="dateStart">Date</label>
+                        <input type="text"
+                            name="dateStart" 
+                            disabled="true"
+                            class="disabled"
+                            [value]="dateEnd | date:'yyyy-MM-dd'" />    
+                    </div>
+                    <div class="input-field">
+                        <ng-content select="[slot=end]"></ng-content>
+                    </div>
                 </div>
             </div>
         </div>
@@ -294,3 +287,19 @@
         </div>
     </div>
 </div>
+
+<ng-template #startTimePickerTpl>
+    <div class="select-header">START: </div>
+        <div class="select-content">
+            <div class="input-field">
+                <label for="dateStart">Date</label>
+                <input type="text" 
+                disabled="true"
+                class="disabled"
+                [value]="dateStart | date:'yyyy-MM-dd'" />
+            </div>
+            <div class="input-field">
+                <ng-container *ngTemplateOutlet="startTimePicker"></ng-container>
+            </div>
+        </div>
+</ng-template>

--- a/src/daterangepicker/daterangepicker.component.html
+++ b/src/daterangepicker/daterangepicker.component.html
@@ -140,12 +140,10 @@
             <div class="select-content">
                 <div class="input-field">
                     <label for="dateStart">Date</label>
-                    <input type="date" 
+                    <input type="text" 
                     disabled="true"
                     class="disabled"
-                    [value]="dateStart | date:'yyyy-MM-dd'" 
-                    (input)="setDateInput($event, sideEnum.left)" 
-                    [max]="dateEnd | date:'yyyy-MM-dd'" />
+                    [value]="dateStart | date:'yyyy-MM-dd'" />
                 </div>
                 <div class="input-field">
                     <ng-content select="[slot=start]"></ng-content>
@@ -270,14 +268,11 @@
             <div class="select-content">
                 <div class="input-field">
                     <label for="dateStart">Date</label>
-                    <input type="date"
+                    <input type="text"
                         name="dateStart" 
                         disabled="true"
                         class="disabled"
-                        [value]="dateEnd | date:'yyyy-MM-dd'" 
-                        (input)="setDateInput($event, sideEnum.right)" 
-                        [min]="dateStart | date:'yyyy-MM-dd'" 
-                        [max]="maxDate.format('YYYY-MM-DD')" />    
+                        [value]="dateEnd | date:'yyyy-MM-dd'" />    
                 </div>
                 <div class="input-field">
                     <ng-content select="[slot=end]"></ng-content>

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectorRef,
   Component,
+  ContentChild,
   ElementRef,
   EventEmitter,
   forwardRef,
@@ -10,6 +11,7 @@ import {
   OnInit,
   Output,
   SimpleChanges,
+  TemplateRef,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
@@ -266,6 +268,8 @@ export class DaterangepickerComponent implements OnInit, OnChanges {
   @Output() cancelClicked: EventEmitter<void>;
   @Output() clearClicked: EventEmitter<void>;
   @ViewChild('pickerContainer', { static: true }) pickerContainer: ElementRef;
+
+  @ContentChild('startTimePicker', { read: TemplateRef }) startTimePicker: TemplateRef<any>;
 
   public chosenLabel: string;
 


### PR DESCRIPTION
- Change disabled date inputs type
Changed inputs date inputs type from `date` to `text`, for consistent value formatting across different browsers. These inputs are always disabled anyway.

- Updated mobile layout to match the designer's vision
Before:
![adscore iterative pl_dashboard](https://github.com/IterativeEngineering/ngx-daterangepicker-material/assets/56605753/1ddd0a60-69de-4e0d-98fc-0242399e09ef)

After:
![localhost_4200_(iPhone SE) (1)](https://github.com/IterativeEngineering/ngx-daterangepicker-material/assets/56605753/2f3ab91e-b273-4a7f-9708-3c50dedad4cb)